### PR TITLE
make help-msg more readable; Header files contain onley declarations

### DIFF
--- a/inc/cache.h
+++ b/inc/cache.h
@@ -1,13 +1,8 @@
 #ifndef CACHE_H
 #define CACHE_H
 
-#include <QDir>
+#include<QString>
 #include <QtSql/QSqlDatabase>
-#include <QtSql/QSqlRecord>
-#include <QtSql/QSqlQuery>
-#include <QVariant>
-#include <sha256.h>
-#include <iostream>
 
 using namespace std;
 

--- a/inc/exec.h
+++ b/inc/exec.h
@@ -1,8 +1,7 @@
 #ifndef EXEC_H
 #define EXEC_H
 
-#include <QFile>
-#include <iostream>
+#include <QString>
 
 using namespace std;
 

--- a/inc/sha256.h
+++ b/inc/sha256.h
@@ -1,10 +1,6 @@
 #ifndef SHA256_H
 #define SHA256_H
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #define UNROLL_LOOPS
 
 #define SHA256_DIGEST_SIZE (256 / 8)

--- a/inc/static_data.h
+++ b/inc/static_data.h
@@ -1,2 +1,17 @@
-char help[] = "\nMessers Heisenberg, AppuDB and Giri, The Purveyors of Speed\n\n<< PRESENTS >>\n\nMedusa 2.7.3 beta\nCopyright (c) 2013-2014, Rahul De, Apoorv Agarwal and Aakash Giri, VIT University\nLicensed under BSD 3-Clause\n\nUsage: medusa [options] file\n\nOptions:\n-install\t Install External Python module\n--help, -h\t Display this information\n-v, --version\t Display the Program Version\n-c\t\t Compile to Dart only\n";
+char help[] = "\nMessers Heisenberg, AppuDB and Giri, The Purveyors of Speed\n"
+              "\n"
+              "<< PRESENTS >>\n"
+              "\n"
+              "Medusa 2.7.3 beta\n"
+              "Copyright (c) 2013-2014, Rahul De, Apoorv Agarwal and Aakash Giri, VIT University\n"
+              "Licensed under BSD 3-Clause\n"
+              "\n"
+              "Usage: medusa [options] file\n"
+              "\n"
+              "Options:\n"
+              "-install         Install External Python module\n"
+              "-h, --help       Display this information\n"
+              "-v, --version    Display the Program Version\n"
+              "-c               Compile to Dart only\n";
+
 char version[] = "2.7.3b";

--- a/inc/transform.h
+++ b/inc/transform.h
@@ -2,11 +2,7 @@
 #define TRANSFORM_H
 
 #include <QObject>
-#include <QDir>
 #include <QtSql/QSqlDatabase>
-#include <QtSql/QSqlRecord>
-#include <QtSql/QSqlQuery>
-#include <QVariant>
 #include <QProcess>
 
 class Transform : public QObject {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1,4 +1,10 @@
 #include <cache.h>
+#include <QDir>
+#include <QtSql/QSqlRecord>
+#include <QtSql/QSqlQuery>
+#include <QVariant>
+#include <sha256.h>
+#include <iostream>
 
 Cache::Cache() {
     QString medusaHome = QDir::homePath() + "/.medusa/";

--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -1,4 +1,6 @@
 #include <exec.h>
+#include <QFile>
+#include <iostream>
 
 void Exec::run(QString code, QString fileName, bool cStop) {
     QFile out(fileName);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <transform.h>
 #include <exec.h>
 #include <static_data.h>
+#include <QDir>
 
 using namespace std;
 

--- a/src/sha256.cpp
+++ b/src/sha256.cpp
@@ -1,4 +1,5 @@
 #include <sha256.h>
+#include <string.h>
 
 uint32 sha256_h0[8] = {
     0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -1,5 +1,8 @@
 #include <iostream>
 #include <transform_moc.h>
+#include <QDir>
+#include <QVariant>
+#include <QtSql/QSqlQuery>
 
 using namespace std;
 


### PR DESCRIPTION
1.  Make help-msg more readable
2.  A *.h file should do nothing but expose interfaces from related cpp file.
3.  Deleted some useless "#include<xxx>" , move some "include" into cpp where it is really used.